### PR TITLE
feat!: add force set value

### DIFF
--- a/src/use-debounced-state/index.ts
+++ b/src/use-debounced-state/index.ts
@@ -6,7 +6,7 @@ import {useRetimer} from '../use-retimer';
 export function useDebouncedState<T>(defaultValue: T | (() => T), wait: number, leading = false) {
   const [value, setValue] = useState<T>(defaultValue);
   const leadingRef = useRef(true);
-  const [retimer, clearRetimer] = useRetimer();
+  const retimer = useRetimer();
 
   const debouncedSetValue = useCallback((newValue: T) => {
     if (leadingRef.current && leading) {
@@ -22,10 +22,10 @@ export function useDebouncedState<T>(defaultValue: T | (() => T), wait: number, 
 
   const forceSetValue = useCallback(
     (newValue: T) => {
-      clearRetimer();
+      retimer.clear();
       setValue(newValue);
     },
-    [clearRetimer]
+    [retimer]
   );
 
   return [value, debouncedSetValue, forceSetValue] as const;

--- a/src/use-debounced-state/index.ts
+++ b/src/use-debounced-state/index.ts
@@ -1,12 +1,12 @@
 import 'client-only';
-import { useCallback, useRef, useState } from 'react';
-import { useRetimer } from '../use-retimer';
+import {useCallback, useRef, useState} from 'react';
+import {useRetimer} from '../use-retimer';
 
 /** @see https://foxact.skk.moe/use-debounced-state */
 export function useDebouncedState<T>(defaultValue: T | (() => T), wait: number, leading = false) {
   const [value, setValue] = useState<T>(defaultValue);
   const leadingRef = useRef(true);
-  const retimer = useRetimer();
+  const [retimer, clearRetimer] = useRetimer();
 
   const debouncedSetValue = useCallback((newValue: T) => {
     if (leadingRef.current && leading) {
@@ -20,5 +20,13 @@ export function useDebouncedState<T>(defaultValue: T | (() => T), wait: number, 
     leadingRef.current = false;
   }, [leading, retimer, wait]);
 
-  return [value, debouncedSetValue] as const;
+  const forceSetValue = useCallback(
+    (newValue: T) => {
+      clearRetimer();
+      setValue(newValue);
+    },
+    [clearRetimer]
+  );
+
+  return [value, debouncedSetValue, forceSetValue] as const;
 }

--- a/src/use-debounced-state/index.ts
+++ b/src/use-debounced-state/index.ts
@@ -1,6 +1,6 @@
 import 'client-only';
-import {useCallback, useRef, useState} from 'react';
-import {useRetimer} from '../use-retimer';
+import { useCallback, useRef, useState } from 'react';
+import { useRetimer } from '../use-retimer';
 
 /** @see https://foxact.skk.moe/use-debounced-state */
 export function useDebouncedState<T>(defaultValue: T | (() => T), wait: number, leading = false) {

--- a/src/use-debounced-state/index.ts
+++ b/src/use-debounced-state/index.ts
@@ -22,7 +22,7 @@ export function useDebouncedState<T>(defaultValue: T | (() => T), wait: number, 
 
   const forceSetValue = useCallback(
     (newValue: T) => {
-      retimer.clear();
+      retimer();
       setValue(newValue);
     },
     [retimer]

--- a/src/use-retimer/index.ts
+++ b/src/use-retimer/index.ts
@@ -3,26 +3,14 @@ import 'client-only';
 
 import { useCallback, useRef } from 'react';
 
-export interface RetimerType {
-  (timerId: number): void,
-  clear: () => void
-}
-
 /** @see https://foxact.skk.moe/use-retimer */
 export const useRetimer = () => {
   const timerIdRef = useRef<number>();
 
-  const retimer = useCallback((timerId: number) => {
+  return useCallback((timerId?: number) => {
     if (typeof timerIdRef.current === 'number') {
       clearTimeout(timerIdRef.current);
     }
     timerIdRef.current = timerId;
-  }, []) as RetimerType;
-
-  retimer.clear = useCallback(() => {
-    clearTimeout(timerIdRef.current);
-    timerIdRef.current = undefined;
   }, []);
-
-  return retimer;
 };

--- a/src/use-retimer/index.ts
+++ b/src/use-retimer/index.ts
@@ -1,12 +1,12 @@
 import 'client-only';
 // useRef is React Client Component only
 
-import {useCallback, useRef} from 'react';
+import { useCallback, useRef } from 'react';
 
-export type RetimerType = {
+export interface RetimerType {
   (timerId: number): void,
   clear: () => void
-};
+}
 
 /** @see https://foxact.skk.moe/use-retimer */
 export const useRetimer = () => {
@@ -24,5 +24,5 @@ export const useRetimer = () => {
     timerIdRef.current = undefined;
   }, []);
 
-  return retimer
+  return retimer;
 };

--- a/src/use-retimer/index.ts
+++ b/src/use-retimer/index.ts
@@ -1,7 +1,12 @@
 import 'client-only';
 // useRef is React Client Component only
 
-import { useCallback, useRef } from 'react';
+import {useCallback, useRef} from 'react';
+
+export type RetimerType = {
+  (timerId: number): void,
+  clear: () => void
+};
 
 /** @see https://foxact.skk.moe/use-retimer */
 export const useRetimer = () => {
@@ -12,12 +17,12 @@ export const useRetimer = () => {
       clearTimeout(timerIdRef.current);
     }
     timerIdRef.current = timerId;
-  }, []);
+  }, []) as RetimerType;
 
-  const clearRetimer = useCallback(() => {
+  retimer.clear = useCallback(() => {
     clearTimeout(timerIdRef.current);
     timerIdRef.current = undefined;
   }, []);
 
-  return [retimer, clearRetimer] as const;
+  return retimer
 };

--- a/src/use-retimer/index.ts
+++ b/src/use-retimer/index.ts
@@ -7,10 +7,17 @@ import { useCallback, useRef } from 'react';
 export const useRetimer = () => {
   const timerIdRef = useRef<number>();
 
-  return useCallback((timerId: number) => {
+  const retimer = useCallback((timerId: number) => {
     if (typeof timerIdRef.current === 'number') {
       clearTimeout(timerIdRef.current);
     }
     timerIdRef.current = timerId;
   }, []);
+
+  const clearRetimer = useCallback(() => {
+    clearTimeout(timerIdRef.current);
+    timerIdRef.current = undefined;
+  }, []);
+
+  return [retimer, clearRetimer] as const;
 };


### PR DESCRIPTION
This will work well at certain times, such as  a search box(swr) with debounced input is submitted by the user.

```typescript
const Page = () => {
  const [debouncedKeyword, setDebouncedKeyword, forceSetValue] =
    useDebouncedState<string>("", 3000);

  const { data } = useSWR(
    debouncedKeyword ? ["/search", debouncedKeyword] : null,
    ([url, keyword]) =>
      fetch(url, {
        method: "POST",
        body: JSON.stringify({ keyword }),
      }).then((res) => res.json()),
  );

  return (
    ...
    <input onSumbit={(e)=> forceSetValue(e.target.value)} />
  )
}
```

I'm not sure this is correct or a best practice.