### PR TITLE
docs: fix typo

### DIFF
--- a/docs/src/pages/use-clipboard.mdx
+++ b/docs/src/pages/use-clipboard.mdx
@@ -21,7 +21,7 @@ const Demo = () => {
     // optional, default to 1000, the duration of the copied state after copying
     timeout: 1000,
     // optional, default to false, whether to use `window.prompt` as fallback when native copy method failed
-    usePromptAsFallback: false
+    usePromptAsFallback: false,
     // optional. When `window.prompt` is used as a fallback, this text will be shown in the prompt dialog
     promptFallbackText: 'Failed to copy to clipboard automatically, please manually copy the text below.',
     // optional. Triggers when copy failed and `usePromptAsFallback` is not enabled


### PR DESCRIPTION
Missing a comma