### PR TITLE
fix(use-debounced-value): unable set and debounce value which is func…

### DIFF
--- a/src/use-debounced-value/index.ts
+++ b/src/use-debounced-value/index.ts
@@ -3,7 +3,7 @@ import { useEffect, useState, useRef } from 'react';
 
 /** @see https://foxact.skk.moe/use-debounced-value */
 export function useDebouncedValue<T>(value: T, wait: number, leading = false) {
-  const [outputValue, setOutputValue] = useState(value);
+  const [outputValue, setOutputValue] = useState(() => value);
   const leadingRef = useRef(true);
 
   useEffect(() => {
@@ -14,11 +14,11 @@ export function useDebouncedValue<T>(value: T, wait: number, leading = false) {
     if (!isCancelled) {
       if (leadingRef.current && leading) {
         leadingRef.current = false;
-        setOutputValue(value);
+        setOutputValue(() => value);
       } else {
         timeout = window.setTimeout(() => {
           leadingRef.current = true;
-          setOutputValue(value);
+          setOutputValue(() => value);
         }, wait);
       }
     }


### PR DESCRIPTION
If my target value type is function, it can't debounced which be used as state init function.
```tsx
const func: ((a: boolean) => string) | undefined = useMemo(() => xxx, [])
const a = useDebouncedValue(func, 100)
```
And if I want to set state init value, it unable infer right type.
```tsx
const a = useDebouncedValue(() => 1, 100)
// a type: () => number
```
But `a` real value is number.