### PR TITLE
fix: correct closing tag for `ComposeContextProvider`

### DIFF
--- a/docs/src/pages/compose-context-provider.mdx
+++ b/docs/src/pages/compose-context-provider.mdx
@@ -85,7 +85,7 @@ export default function RootLayout({ children }) {
         {/** composed providers */}
         <ComposeContextProvider contexts={contexts}>
           {children}
-        </SidebarActiveProvider>
+        </ComposeContextProvider>
       </body>
     </html>
   );


### PR DESCRIPTION
## Description

Fixed incorrect closing tag in `ComposeContextProvider` documentation for improved clarity.