### PR TITLE
feat: add useComponentWillReceiveUpdate

### DIFF
--- a/docs/src/pages/use-component-will-receive-update.mdx
+++ b/docs/src/pages/use-component-will-receive-update.mdx
@@ -55,7 +55,7 @@ If you need to edit other components' states, write it like this:
 
 ```js
 useComponentWillReceiveUpdate(() => {
-  setLocalState(false)
-  flushSync(() => props.setParentState(false))
+  flushSync(() => setLocalState(false))
+  props.setParentState(false)
 }, [state])
 ```

--- a/docs/src/pages/use-component-will-receive-update.mdx
+++ b/docs/src/pages/use-component-will-receive-update.mdx
@@ -55,7 +55,11 @@ If you need to edit other components' states, write it like this:
 
 ```js
 useComponentWillReceiveUpdate(() => {
+  // Force React to immediately flush scheduled/batched updates
   flushSync(() => setLocalState(false))
+  // By the time flushSync finishes and reaches this line, the DOM update
+  // for local state change has finished, you can now safely trigger parent
+  // components' re-render.
   props.setParentState(false)
 }, [state])
 ```

--- a/docs/src/pages/use-component-will-receive-update.mdx
+++ b/docs/src/pages/use-component-will-receive-update.mdx
@@ -1,0 +1,62 @@
+---
+title: useComponentWillReceiveUpdate
+---
+
+# useComponentWillReceiveUpdate
+
+import ExportMetaInfo from '../components/export-meta-info';
+
+<ExportMetaInfo />
+
+Reset part of states when props changed.
+
+## Usage
+
+```js
+import { useComponentWillReceiveUpdate } from 'foxact/use-abortable-effect';
+
+function Component(props) {
+  const [a, setA] = useState('')
+  const [b, setB] = useState('')
+  // when props.x changed, only reset a, not b
+  useComponentWillReceiveUpdate(() => {
+    setA('')
+  }, [props.x]);
+}
+```
+
+If you're using useEffect like this:
+
+```js
+  const [state, setState] = useState(false)
+  useEffect(() => setState(false), [props.someProp])
+```
+
+Don't do it. See [Adjusting some state when a prop changes](https://react.dev/learn/you-might-not-need-an-effect#adjusting-some-state-when-a-prop-changes)
+It should be like this:
+```js
+  const [prev, setPrev] = useState(state)
+  if (prev !== state) {
+    setPrev(state)
+    setState(false)
+  }
+```
+
+This hook is a helper for the above pattern.
+
+```js
+useComponentWillReceiveUpdate(() => setState(false), [state])
+```
+
+This only applies to states of the current component.
+Modifying states from other components causes React reporting errors.
+You may also want to read [(Avoid) Notifying parent components about state changes](https://react.dev/learn/you-might-not-need-an-effect#notifying-parent-components-about-state-changes)
+and [(Avoid) Passing data to the parent](https://react.dev/learn/you-might-not-need-an-effect#passing-data-to-the-parent).
+If you really need to edit other components' states, write it like this:
+
+```js
+useComponentWillReceiveUpdate(() => {
+  setLocalState(false)
+  Promise.resolve().then(() => props.setParentState(false))
+}, [state])
+```

--- a/docs/src/pages/use-component-will-receive-update.mdx
+++ b/docs/src/pages/use-component-will-receive-update.mdx
@@ -32,7 +32,7 @@ If you're using useEffect like this:
   useEffect(() => setState(false), [props.someProp])
 ```
 
-Don't do it. See [Adjusting some state when a prop changes](https://react.dev/learn/you-might-not-need-an-effect#adjusting-some-state-when-a-prop-changes)
+Don't do it. See [Adjusting some state when a prop changes](https://react.dev/learn/you-might-not-need-an-effect#adjusting-some-state-when-a-prop-changes) or [Storing information from previous renders](https://react.dev/reference/react/useState#storing-information-from-previous-renders)
 It should be like this:
 ```js
   const [prev, setPrev] = useState(state)
@@ -50,9 +50,8 @@ useComponentWillReceiveUpdate(() => setState(false), [state])
 
 This only applies to states of the current component.
 Modifying states from other components causes React reporting errors.
-You may also want to read [(Avoid) Notifying parent components about state changes](https://react.dev/learn/you-might-not-need-an-effect#notifying-parent-components-about-state-changes)
-and [(Avoid) Passing data to the parent](https://react.dev/learn/you-might-not-need-an-effect#passing-data-to-the-parent).
-If you really need to edit other components' states, write it like this:
+You may also want to read [(Avoid) Notifying parent components about state changes](https://react.dev/learn/you-might-not-need-an-effect#notifying-parent-components-about-state-changes) and [(Avoid) Passing data to the parent](https://react.dev/learn/you-might-not-need-an-effect#passing-data-to-the-parent).
+If you need to edit other components' states, write it like this:
 
 ```js
 useComponentWillReceiveUpdate(() => {

--- a/docs/src/pages/use-component-will-receive-update.mdx
+++ b/docs/src/pages/use-component-will-receive-update.mdx
@@ -54,6 +54,8 @@ You may also want to read [(Avoid) Notifying parent components about state chang
 If you need to edit other components' states, write it like this:
 
 ```js
+import { flushSync } from 'react-dom'
+
 useComponentWillReceiveUpdate(() => {
   // Force React to immediately flush scheduled/batched updates
   flushSync(() => setLocalState(false))

--- a/docs/src/pages/use-component-will-receive-update.mdx
+++ b/docs/src/pages/use-component-will-receive-update.mdx
@@ -8,7 +8,7 @@ import ExportMetaInfo from '../components/export-meta-info';
 
 <ExportMetaInfo />
 
-Reset part of states when props changed.
+Change states based on changed props during a re-render. The name of the hook comes from [`UNSAFE_componentWillReceiveProps` method of class components](https://react.dev/reference/react/Component#unsafe_componentwillreceiveprops).
 
 ## Usage
 

--- a/docs/src/pages/use-component-will-receive-update.mdx
+++ b/docs/src/pages/use-component-will-receive-update.mdx
@@ -35,11 +35,11 @@ If you're using useEffect like this:
 Don't do it. See [Adjusting some state when a prop changes](https://react.dev/learn/you-might-not-need-an-effect#adjusting-some-state-when-a-prop-changes) or [Storing information from previous renders](https://react.dev/reference/react/useState#storing-information-from-previous-renders)
 It should be like this:
 ```js
-  const [prev, setPrev] = useState(state)
-  if (prev !== state) {
-    setPrev(state)
-    setState(false)
-  }
+const [prev, setPrev] = useState(state)
+if (prev !== state) {
+  setPrev(state)
+  setState(false)
+}
 ```
 
 This hook is a helper for the above pattern.
@@ -56,6 +56,6 @@ If you need to edit other components' states, write it like this:
 ```js
 useComponentWillReceiveUpdate(() => {
   setLocalState(false)
-  Promise.resolve().then(() => props.setParentState(false))
+  flushSync(() => props.setParentState(false))
 }, [state])
 ```

--- a/docs/src/pages/use-component-will-receive-update.mdx
+++ b/docs/src/pages/use-component-will-receive-update.mdx
@@ -48,10 +48,9 @@ This hook is a helper for the above pattern.
 useComponentWillReceiveUpdate(() => setState(false), [state])
 ```
 
-This only applies to states of the current component.
-Modifying states from other components causes React reporting errors.
-You may also want to read [(Avoid) Notifying parent components about state changes](https://react.dev/learn/you-might-not-need-an-effect#notifying-parent-components-about-state-changes) and [(Avoid) Passing data to the parent](https://react.dev/learn/you-might-not-need-an-effect#passing-data-to-the-parent).
-If you need to edit other components' states, write it like this:
+This should only apply to states of the current component. Modifying states of other components causes React reporting errors. You may also want to read [(Avoid) Notifying parent components about state changes](https://react.dev/learn/you-might-not-need-an-effect#notifying-parent-components-about-state-changes) and [(Avoid) Passing data to the parent](https://react.dev/learn/you-might-not-need-an-effect#passing-data-to-the-parent).
+
+If you really need to directly modify other components' states (E.g. when working with third-party libraries/components/SDKs where you don't have control of that code), use `flushSync` to separate two state updates:
 
 ```js
 import { flushSync } from 'react-dom'

--- a/src/use-component-will-receive-update/index.ts
+++ b/src/use-component-will-receive-update/index.ts
@@ -38,15 +38,15 @@ import { useState } from 'react';
  * @param deps
  */
 export function useComponentWillReceiveUpdate(callback: () => void, deps: readonly unknown[]) {
-    deps = [...deps]
-    const [prev, setPrev] = useState(deps)
-    let changed = deps.length !== prev.length
-    for (let i = 0; i < deps.length; i += 1) {
-        if (changed) break
-        if (prev[i] !== deps[i]) changed = true
-    }
-    if (changed) {
-        setPrev(deps)
-        callback()
-    }
+  deps = [...deps];
+  const [prev, setPrev] = useState(deps);
+  let changed = deps.length !== prev.length;
+  for (let i = 0; i < deps.length; i += 1) {
+    if (changed) break;
+    if (prev[i] !== deps[i]) changed = true;
+  }
+  if (changed) {
+    setPrev(deps);
+    callback();
+  }
 }

--- a/src/use-component-will-receive-update/index.ts
+++ b/src/use-component-will-receive-update/index.ts
@@ -1,42 +1,8 @@
 import { useState } from 'react';
 
 /**
- * If you're using useEffect like this:
- *
- * ```js
- * const [state, setState] = useState(false)
- * useEffect(() => setState(false), [props.someProp])
- * ```
- * Don't do it. See [Adjusting some state when a prop changes](https://react.dev/learn/you-might-not-need-an-effect#adjusting-some-state-when-a-prop-changes)
- * It should be like this:
- * ```js
- * const [prev, setPrev] = useState(state)
- * if (prev !== state) {
- *     setPrev(state)
- *     setState(false)
- * }
- * ```
- * This hook is a helper for the above pattern.
- * ```js
- * useComponentWillReceiveUpdate(() => setState(false), [state])
- * ```
- *
- * This only applies to states of the current component.
- * Modifying states from other components causes React reporting errors.
- * You may also want to read [(Avoid) Notifying parent components about state changes](https://react.dev/learn/you-might-not-need-an-effect#notifying-parent-components-about-state-changes)
- * and [(Avoid) Passing data to the parent](https://react.dev/learn/you-might-not-need-an-effect#passing-data-to-the-parent).
- * If you really need to edit other components' states, write it like this:
- *
- * ```js
- * useComponentWillReceiveUpdate(() => {
- *     setLocalState(false)
- *     Promise.resolve().then(() => props.setParentState(false))
- * }, [state])
- * ```
- *
- * @param callback
- * @param deps
- */
+  * @see {https://foxact.skk.moe/use-component-will-receive-update}
+  */
 export function useComponentWillReceiveUpdate(callback: () => void, deps: readonly unknown[]) {
   deps = [...deps];
   const [prev, setPrev] = useState(deps);

--- a/src/use-component-will-receive-update/index.ts
+++ b/src/use-component-will-receive-update/index.ts
@@ -1,0 +1,52 @@
+import { useState } from 'react';
+
+/**
+ * If you're using useEffect like this:
+ *
+ * ```js
+ * const [state, setState] = useState(false)
+ * useEffect(() => setState(false), [props.someProp])
+ * ```
+ * Don't do it. See [Adjusting some state when a prop changes](https://react.dev/learn/you-might-not-need-an-effect#adjusting-some-state-when-a-prop-changes)
+ * It should be like this:
+ * ```js
+ * const [prev, setPrev] = useState(state)
+ * if (prev !== state) {
+ *     setPrev(state)
+ *     setState(false)
+ * }
+ * ```
+ * This hook is a helper for the above pattern.
+ * ```js
+ * useComponentWillReceiveUpdate(() => setState(false), [state])
+ * ```
+ *
+ * This only applies to states of the current component.
+ * Modifying states from other components causes React reporting errors.
+ * You may also want to read [(Avoid) Notifying parent components about state changes](https://react.dev/learn/you-might-not-need-an-effect#notifying-parent-components-about-state-changes)
+ * and [(Avoid) Passing data to the parent](https://react.dev/learn/you-might-not-need-an-effect#passing-data-to-the-parent).
+ * If you really need to edit other components' states, write it like this:
+ *
+ * ```js
+ * useComponentWillReceiveUpdate(() => {
+ *     setLocalState(false)
+ *     Promise.resolve().then(() => props.setParentState(false))
+ * }, [state])
+ * ```
+ *
+ * @param callback
+ * @param deps
+ */
+export function useComponentWillReceiveUpdate(callback: () => void, deps: readonly unknown[]) {
+    deps = [...deps]
+    const [prev, setPrev] = useState(deps)
+    let changed = deps.length !== prev.length
+    for (let i = 0; i < deps.length; i += 1) {
+        if (changed) break
+        if (prev[i] !== deps[i]) changed = true
+    }
+    if (changed) {
+        setPrev(deps)
+        callback()
+    }
+}


### PR DESCRIPTION
# useComponentWillReceiveUpdate

Reset part of states when props changed.

## Usage

```js
import { useComponentWillReceiveUpdate } from 'foxact/use-abortable-effect';

function Component(props) {
  const [a, setA] = useState('')
  const [b, setB] = useState('')
  // when props.x changed, only reset a, not b
  useComponentWillReceiveUpdate(() => {
    setA('')
  }, [props.x]);
}
```

If you're using useEffect like this:

```js
  const [state, setState] = useState(false)
  useEffect(() => setState(false), [props.someProp])
```

Don't do it. See [Adjusting some state when a prop changes](https://react.dev/learn/you-might-not-need-an-effect#adjusting-some-state-when-a-prop-changes)
It should be like this:
```js
  const [prev, setPrev] = useState(state)
  if (prev !== state) {
    setPrev(state)
    setState(false)
  }
```

This hook is a helper for the above pattern.

```js
useComponentWillReceiveUpdate(() => setState(false), [state])
```

This only applies to states of the current component.
Modifying states from other components causes React reporting errors.
You may also want to read [(Avoid) Notifying parent components about state changes](https://react.dev/learn/you-might-not-need-an-effect#notifying-parent-components-about-state-changes)
and [(Avoid) Passing data to the parent](https://react.dev/learn/you-might-not-need-an-effect#passing-data-to-the-parent).
If you really need to edit other components' states, write it like this:

```js
useComponentWillReceiveUpdate(() => {
  setLocalState(false)
  Promise.resolve().then(() => props.setParentState(false))
}, [state])
```