### PR TITLE
fix(useRetimer): improve `timerId` typing

### DIFF
--- a/src/use-retimer/index.ts
+++ b/src/use-retimer/index.ts
@@ -3,11 +3,13 @@ import 'client-only';
 
 import { useCallback, useRef } from 'react';
 
+type Timer = number | ReturnType<typeof setTimeout>;
+
 /** @see https://foxact.skk.moe/use-retimer */
 export function useRetimer() {
-  const timerIdRef = useRef<number>();
+  const timerIdRef = useRef<Timer>();
 
-  return useCallback((timerId?: number | ReturnType<typeof setTimeout>) => {
+  return useCallback((timerId?: Timer) => {
     if (typeof timerIdRef.current === 'number') {
       clearTimeout(timerIdRef.current);
     }

--- a/src/use-retimer/index.ts
+++ b/src/use-retimer/index.ts
@@ -7,7 +7,7 @@ import { useCallback, useRef } from 'react';
 export function useRetimer() {
   const timerIdRef = useRef<number>();
 
-  return useCallback((timerId?: number) => {
+  return useCallback((timerId?: number | ReturnType<typeof setTimeout>) => {
     if (typeof timerIdRef.current === 'number') {
       clearTimeout(timerIdRef.current);
     }


### PR DESCRIPTION
Avoid Typescript throws an error: Type 'Timer' is not assignable to type 'number'.
https://stackoverflow.com/questions/51040703/what-return-type-should-be-used-for-settimeout-in-typescript