### PR TITLE
fix(docs):  "Server-side" typo

### DIFF
--- a/packages/docs/src/pages/create-local-storage-state.mdx
+++ b/packages/docs/src/pages/create-local-storage-state.mdx
@@ -63,7 +63,7 @@ function Sidebar() {
 export default memo(Sidebar);
 ```
 
-## Sever-side Rendering
+## Server-side Rendering
 
 If the second argument (the initial value) is provided, React will use the initial value to render the UI and generate HTML on the server, otherwise React will find the closest `<Suspense>` boundary and render its `fallback` UI into the generated server HTML on the server. See 
-[`useLocalStorage`](/use-local-storage#sever-side-rendering) for more information.
+[`useLocalStorage`](/use-local-storage#server-side-rendering) for more information.

--- a/packages/docs/src/pages/create-session-storage-state.mdx
+++ b/packages/docs/src/pages/create-session-storage-state.mdx
@@ -61,6 +61,6 @@ function Sidebar() {
 export default memo(Sidebar);
 ```
 
-## Sever-side Rendering
+## Server-side Rendering
 
-See [createLocalStorageState](/create-local-storage-state#sever-side-rendering) for more details.
+See [createLocalStorageState](/create-local-storage-state#server-side-rendering) for more details.

--- a/packages/docs/src/pages/use-local-storage.mdx
+++ b/packages/docs/src/pages/use-local-storage.mdx
@@ -53,7 +53,7 @@ const Comp = () => {
 };
 ```
 
-## Sever-side Rendering
+## Server-side Rendering
 
 If the second argument (the initial value) is provided, React will use the initial value to render the UI and generate HTML on the server. The user will see the initial value (which might be stale) first. On the client, React will first use the initial value to hydrate the server-side rendered HTML, and then immediately re-render the component with the actual value (read from the browser's `localStorage`) after the hydration. The user will see the latest value stored in the browser's `localStorage` after both the hydration and the re-render.
 

--- a/packages/docs/src/pages/use-media-query.mdx
+++ b/packages/docs/src/pages/use-media-query.mdx
@@ -24,7 +24,7 @@ export default function Component() {
 }
 ```
 
-## Sever-side Rendering
+## Server-side Rendering
 
 If the second argument (the initial value) is provided, React will use the initial value to render the UI and generate HTML on the server. The user will see the initial value (which might be stale) first. On the client, React will first use the initial value to hydrate the server-side rendered HTML, and then immediately re-render the component with the actual value (read from the browser's `matchMedia()` API) after the hydration. The user will see the latest value after both the hydration and the re-render.
 

--- a/packages/docs/src/pages/use-session-storage.mdx
+++ b/packages/docs/src/pages/use-session-storage.mdx
@@ -53,6 +53,6 @@ const Comp = () => {
 };
 ```
 
-## Sever-side Rendering
+## Server-side Rendering
 
-See [useLocalStorage](/use-local-storage#sever-side-rendering) for more details.
+See [useLocalStorage](/use-local-storage#server-side-rendering) for more details.


### PR DESCRIPTION
This pull request fixes a typo in multiple documentation files by correcting "Sever-side Rendering" to "Server-side Rendering" and updating related links.