### PR TITLE
fix: ts error 

### DIFF
--- a/packages/foxact/src/context-state/index.tsx
+++ b/packages/foxact/src/context-state/index.tsx
@@ -5,7 +5,7 @@ import { createContext, useContext, useState } from 'react';
 import { noop } from '../noop';
 import type { Foxact } from '../types';
 
-interface ProviderProps<T> {
+export interface ProviderProps<T> {
   initialState?: T | (() => T)
 }
 


### PR DESCRIPTION
`TS4023: Exported variable * has or is using name ProviderProps from external module`