### PR TITLE
feat: introduce `browser`

### DIFF
--- a/packages/docs/src/app/_meta.ts
+++ b/packages/docs/src/app/_meta.ts
@@ -77,6 +77,7 @@ export default {
     title: 'Utilities'
   },
   breadcrumbs: {},
+  browser: {},
   'context-reducer': {},
   'context-state': {},
   'create-local-storage-state': {},

--- a/packages/docs/src/app/browser/page.mdx
+++ b/packages/docs/src/app/browser/page.mdx
@@ -1,0 +1,131 @@
+---
+title: browser
+---
+
+# browser
+
+import ExportMetaInfo from '../../components/export-meta-info';
+
+<ExportMetaInfo />
+
+Mark a component as browser-only during server rendering.
+
+This is [React DOM's `browser()` API](https://react.dev/reference/react-dom/browser) (currently only available in React's Canary channel), with a compatibility implementation for React DOM releases that don't ship it yet: when `react-dom` exports `browser`, foxact hands you the native implementation as is. Otherwise, foxact provides a polyfill built on the same mechanism as [`noSSR`](/no-ssr), so it works with React 18 and React 19.2 as well.
+
+During stream server-side rendering, `use(browser())` stops rendering the component and leaves the closest `<Suspense>` boundary's fallback in the generated HTML. In the browser, `use(browser())` returns `undefined` and the component renders normally: the user sees the fallback first when the page loads, and the actual content once React hydrates the page. See [Rendering content only in the browser](https://react.dev/reference/react-dom/browser#rendering-content-only-in-the-browser) at React docs.
+
+import { Callout } from 'nextra/components'
+
+<Callout type="warning" emoji="⚠️">
+`use(browser())` must be inside a `<Suspense>` boundary during server rendering. Without one, the server render fails.
+</Callout>
+
+<Callout type="warning" emoji="⚠️">
+Like `noSSR`, `browser()` only works with React stream server-side rendering (`renderToPipeableStream`, `renderToReadableStream`, and frameworks built on them like Next.js). If you are using the synchronous `renderToString`, use [`useIsClient`](/use-is-client) instead.
+</Callout>
+
+## Usage
+
+```tsx filename="src/editor.tsx" copy
+import { use } from 'react';
+import { browser } from 'foxact/browser';
+
+function BrowserOnlyEditor() {
+  use(browser('The editor requires browser APIs.'));
+
+  return <label>Draft: <input /></label>;
+}
+```
+
+```tsx filename="src/app.tsx" copy
+<Suspense fallback={<p>Loading editor...</p>}>
+  <BrowserOnlyEditor />
+</Suspense>
+```
+
+The server HTML will include `<p>Loading editor...</p>`. It will be replaced by the `<BrowserOnlyEditor />` component in the browser.
+
+`use` is React 19's `use`. On React 18, import it from `foxact/use` instead, which polyfills `use` for the values `browser()` returns.
+
+In a React Server Components app (e.g. Next.js App Router), `use(browser())` must be called from a Client Component, not a Server Component:
+
+```tsx filename="src/editor.tsx" copy
+'use client';
+
+import { use } from 'react';
+import { browser } from 'foxact/browser';
+
+export default function BrowserOnlyEditor() {
+  use(browser('The editor requires browser APIs.'));
+
+  return <Editor />;
+}
+```
+
+### Conditionally rendering in the browser
+
+Unlike other hooks, `use` can be called conditionally, so you can bail out to the browser only when something is missing:
+
+```tsx filename="src/use-browser-query.ts" copy
+import { use } from 'react';
+import { browser } from 'foxact/browser';
+
+function useBrowserQuery(query, options) {
+  if (options.initialData === undefined) {
+    use(browser('useBrowserQuery: No initial data was provided.'));
+  }
+
+  return useQuery(query, options);
+}
+```
+
+### Providing a reason
+
+`browser()` accepts an optional `reason`, either a string or a function returning anything (e.g. `() => new Error('...')`). The string, or the function's return value, becomes the `cause` of the error reported by the server renderer, which is handy when you want to find out where and why your server HTML bails out to the browser.
+
+The function is only called by the server renderer and never in the browser, so pass a function when creating the reason is expensive.
+
+## Differences from React DOM's native `browser()`
+
+When `react-dom` doesn't export `browser` (React DOM 19.2 and below), foxact's polyfill returns a value that `use()` unwraps to `undefined` in the browser, and that makes `use()` throw a recoverable error on the server. It is the same error [`noSSR()`](/no-ssr) throws, carrying the Next.js `BAILOUT_TO_CLIENT_SIDE_RENDERING` digest and a `recoverableError: 'NO_SSR'` marker. The generated HTML is the same as with the native implementation, but the way the bailout is reported differs:
+
+- The server renderer reports the bailout to `onError` instead of `onBrowserBailout`. If you are calling `renderToPipeableStream` / `renderToReadableStream` yourself, filter it out, and return its `digest` so the browser can recognize it:
+
+```tsx filename="server.tsx" copy
+const { pipe } = renderToPipeableStream(<App />, {
+  onError(error) {
+    if (error && typeof error === 'object' && 'recoverableError' in error && error.recoverableError === 'NO_SSR') {
+      // A deliberate bailout requested by `browser()` (or `noSSR()`), not an error.
+      // Return the digest so the browser can tell it apart from real server errors.
+      return error.digest;
+    }
+
+    console.error(error);
+  }
+});
+```
+
+- In the browser, React reports the client-rendered boundary to `hydrateRoot`'s `onRecoverableError` (the native implementation doesn't). Filter it out by the digest you returned above:
+
+```tsx filename="src/index.tsx" copy
+import { hydrateRoot } from 'react-dom/client';
+import { App } from './app';
+
+hydrateRoot(document.getElementById('root'), <App />, {
+  onRecoverableError(error) {
+    if (error && typeof error === 'object' && 'digest' in error && error.digest === 'BAILOUT_TO_CLIENT_SIDE_RENDERING') {
+      // Ignoring the recoverable error generated by `browser()` (or `noSSR()`).
+      return;
+    }
+
+    // handle other errors
+    // ...
+  }
+});
+```
+
+Next.js already handles both of them.
+
+- Passing `browser()` as the reason of `abort()` to [abort a pending server render for the browser](https://react.dev/reference/react-dom/browser#aborting-pending-server-rendering-for-the-browser) is only supported by the native implementation.
+
+Once you upgrade to a React DOM that ships `browser()`, foxact hands you the native implementation, and all the differences above go away without any code change.

--- a/packages/docs/src/app/browser/page.mdx
+++ b/packages/docs/src/app/browser/page.mdx
@@ -10,7 +10,7 @@ import ExportMetaInfo from '../../components/export-meta-info';
 
 Mark a component as browser-only during server rendering.
 
-This is [React DOM's `browser()` API](https://react.dev/reference/react-dom/browser) (currently only available in React's Canary channel), with a compatibility implementation for React DOM releases that don't ship it yet: when `react-dom` exports `browser`, foxact hands you the native implementation as is. Otherwise, foxact provides a polyfill built on the same mechanism as [`noSSR`](/no-ssr), so it works with React 18 and React 19.2 as well.
+This is [React DOM's `browser()` API](https://react.dev/reference/react-dom/browser) with a compatibility implementation for React DOM versions that don't ship it yet, where foxact provides a polyfill built on the same mechanism as [`noSSR`](/no-ssr), so it works with React 18 and React 19.2 as well.
 
 During stream server-side rendering, `use(browser())` stops rendering the component and leaves the closest `<Suspense>` boundary's fallback in the generated HTML. In the browser, `use(browser())` returns `undefined` and the component renders normally: the user sees the fallback first when the page loads, and the actual content once React hydrates the page. See [Rendering content only in the browser](https://react.dev/reference/react-dom/browser#rendering-content-only-in-the-browser) at React docs.
 
@@ -26,58 +26,30 @@ Like `noSSR`, `browser()` only works with React stream server-side rendering (`r
 
 ## Usage
 
-```tsx filename="src/editor.tsx" copy
-import { use } from 'react';
-import { browser } from 'foxact/browser';
-
-function BrowserOnlyEditor() {
-  use(browser('The editor requires browser APIs.'));
-
-  return <label>Draft: <input /></label>;
-}
-```
-
-```tsx filename="src/app.tsx" copy
-<Suspense fallback={<p>Loading editor...</p>}>
-  <BrowserOnlyEditor />
-</Suspense>
-```
-
-The server HTML will include `<p>Loading editor...</p>`. It will be replaced by the `<BrowserOnlyEditor />` component in the browser.
-
-`use` is React 19's `use`. On React 18, import it from `foxact/use` instead, which polyfills `use` for the values `browser()` returns.
-
-In a React Server Components app (e.g. Next.js App Router), `use(browser())` must be called from a Client Component, not a Server Component:
+A code editor like [CodeMirror](https://codemirror.net/) is the textbook case: constructing an `EditorView` builds and measures its own DOM and sniffs `navigator` for platform-specific key bindings, so the component cannot be rendered on the server at all.
 
 ```tsx filename="src/editor.tsx" copy
 'use client';
 
 import { use } from 'react';
 import { browser } from 'foxact/browser';
+import CodeMirror from '@uiw/react-codemirror';
+import { javascript } from '@codemirror/lang-javascript';
 
-export default function BrowserOnlyEditor() {
-  use(browser('The editor requires browser APIs.'));
+function Editor({ value, onChange }) {
+  use(browser('CodeMirror needs a real DOM to construct its EditorView.'));
 
-  return <Editor />;
+  return <CodeMirror value={value} extensions={[javascript()]} onChange={onChange} />;
 }
 ```
 
-### Conditionally rendering in the browser
-
-Unlike other hooks, `use` can be called conditionally, so you can bail out to the browser only when something is missing:
-
-```tsx filename="src/use-browser-query.ts" copy
-import { use } from 'react';
-import { browser } from 'foxact/browser';
-
-function useBrowserQuery(query, options) {
-  if (options.initialData === undefined) {
-    use(browser('useBrowserQuery: No initial data was provided.'));
-  }
-
-  return useQuery(query, options);
-}
+```tsx filename="src/app.tsx" copy
+<Suspense fallback={<pre>Loading editor...</pre>}>
+  <Editor value={draft} onChange={setDraft} />
+</Suspense>
 ```
+
+The server HTML will include `<pre>Loading editor...</pre>`. It will be replaced by the `<Editor />` component in the browser.
 
 ### Providing a reason
 

--- a/packages/docs/src/app/no-ssr/page.mdx
+++ b/packages/docs/src/app/no-ssr/page.mdx
@@ -6,19 +6,22 @@ title: No SSR
 
 
 import ExportMetaInfo from '../../components/export-meta-info';
+import { Callout } from 'nextra/components'
 
 <ExportMetaInfo />
 
-Force React stream server-side rendering to include the closet `<Suspense>` boundary's fallback UI (e.g. a loading indicator) into the generated server HTML. On the browser, the user will see the fallback UI first when the page loads, while React attempts to render the same component again during the hydration, and the user will see the proper content once React finishes the hydration. See [\<Suspense\> Providing a fallback for server errors and client-only content](https://react.dev/reference/react/Suspense#providing-a-fallback-for-server-errors-and-client-only-content) at React docs.
+<Callout type="warning" emoji="⚠️">
+**Use [`browser`](/browser) instead whenever you can.** `noSSR` predates React's own solution to this problem, and it is only a workaround: it bails out by throwing an error that the server renderer, the browser, and your framework all have to be taught to recognize as deliberate.
 
-import { Callout } from 'nextra/components'
+React DOM now ships an official API [`use(browser())`](https://react.dev/reference/react-dom/browser) for the same use case, and foxact has since shipped [`foxact/browser`](/browser) (which is a re-export and automatically falls back to `noSSR`-based polyfill) that is safe for you to adopt today even on React 18.
+
+`noSSR` itself remains supported for backward compatibility.
+</Callout>
+
+Force React stream server-side rendering to include the closet `<Suspense>` boundary's fallback UI (e.g. a loading indicator) into the generated server HTML. On the browser, the user will see the fallback UI first when the page loads, while React attempts to render the same component again during the hydration, and the user will see the proper content once React finishes the hydration. See [\<Suspense\> Providing a fallback for server errors and client-only content](https://react.dev/reference/react/Suspense#providing-a-fallback-for-server-errors-and-client-only-content) at React docs.
 
 <Callout type="warning" emoji="⚠️">
 The `noSSR` function can only be used with React stream server-side rendering. If you are using the React synchronous server-side rendering (e.g. `renderToString`), you should use the `useIsClient` approach instead. See [`useIsClient`](/use-is-client).
-</Callout>
-
-<Callout type="info">
-React DOM now ships an official API for this, [`use(browser())`](https://react.dev/reference/react-dom/browser). foxact provides it as [`browser`](/browser), with a fallback (built on `noSSR`) for React DOM releases that don't ship it yet.
 </Callout>
 
 ## Usage

--- a/packages/docs/src/app/no-ssr/page.mdx
+++ b/packages/docs/src/app/no-ssr/page.mdx
@@ -17,6 +17,10 @@ import { Callout } from 'nextra/components'
 The `noSSR` function can only be used with React stream server-side rendering. If you are using the React synchronous server-side rendering (e.g. `renderToString`), you should use the `useIsClient` approach instead. See [`useIsClient`](/use-is-client).
 </Callout>
 
+<Callout type="info">
+React DOM now ships an official API for this, [`use(browser())`](https://react.dev/reference/react-dom/browser). foxact provides it as [`browser`](/browser), with a fallback (built on `noSSR`) for React DOM releases that don't ship it yet.
+</Callout>
+
 ## Usage
 
 ```tsx filename="src/chat.tsx" copy

--- a/packages/foxact/src/browser/__fixtures__/server-realm.tsx
+++ b/packages/foxact/src/browser/__fixtures__/server-realm.tsx
@@ -1,0 +1,128 @@
+import { Writable } from 'node:stream';
+import { Suspense, use } from 'react';
+import { renderToPipeableStream } from 'react-dom/server';
+import { extractErrorMessage } from 'foxts/extract-error-message';
+import { browser } from '..';
+import type { BrowserReason } from '..';
+
+// Runs inside the server-realm worker (see test/server-realm), where
+// `typeof window === 'undefined'` natively, without any global juggling.
+
+export interface SerializedBailoutError {
+  message: string,
+  hasCause: boolean,
+  cause: string | null,
+  digest: string | undefined,
+  recoverableError: string | undefined,
+  stackless: boolean
+}
+
+export interface StreamResult {
+  html: string,
+  shellError: string | null,
+  errors: SerializedBailoutError[]
+}
+
+export interface ServerRealmFixtureResult {
+  typeofWindow: string,
+  status: string,
+  error: SerializedBailoutError,
+  withoutReason: SerializedBailoutError,
+  lazyReason: SerializedBailoutError & { initializerCalls: number },
+  throwingReason: SerializedBailoutError,
+  inSuspense: StreamResult,
+  outsideSuspense: StreamResult
+}
+
+function describeCause(cause: unknown): string | null {
+  if (cause === undefined) return null;
+  if (typeof cause === 'string') return cause;
+  return extractErrorMessage(cause, false) ?? 'unknown cause';
+}
+
+function serializeError(error: unknown): SerializedBailoutError {
+  // custom error properties don't survive the structured clone boundary, so
+  // serialize what the assertions need by hand
+  const e = error as Error & { digest?: string, recoverableError?: string, cause?: unknown };
+
+  return {
+    message: extractErrorMessage(e, false) ?? 'Unknown error',
+    hasCause: 'cause' in e,
+    cause: describeCause(e.cause),
+    digest: e.digest,
+    recoverableError: e.recoverableError,
+    stackless: !(e.stack ?? '').includes('\n    at ')
+  };
+}
+
+function Editor({ reason }: { reason?: BrowserReason }) {
+  use(browser(reason));
+  return <span>editor</span>;
+}
+
+function renderToStreamString(element: React.ReactNode) {
+  return new Promise<StreamResult>((resolve) => {
+    const chunks: Buffer[] = [];
+    const errors: SerializedBailoutError[] = [];
+
+    const writable = new Writable({
+      write(chunk: Buffer, _encoding, callback) {
+        chunks.push(chunk);
+        callback();
+      },
+      final(callback) {
+        resolve({ html: Buffer.concat(chunks).toString('utf8'), shellError: null, errors });
+        callback();
+      }
+    });
+
+    const { pipe } = renderToPipeableStream(element, {
+      onAllReady() {
+        pipe(writable);
+      },
+      onShellError(error) {
+        resolve({ html: '', shellError: extractErrorMessage(error) ?? 'Unknown server rendering error', errors });
+      },
+      onError(error) {
+        errors.push(serializeError(error));
+        // what a framework does (e.g. Next.js): forward the digest so the browser
+        // can tell a deliberate bailout apart from a real server error
+        return (error as { digest?: string }).digest;
+      }
+    });
+  });
+}
+
+export default async function run(): Promise<ServerRealmFixtureResult> {
+  const usable = browser('The editor requires browser APIs.');
+
+  let initializerCalls = 0;
+  const lazy = browser(() => {
+    initializerCalls++;
+    return new Error('lazy reason');
+  });
+
+  const throwing = browser(() => {
+    throw new Error('initializer exploded');
+  });
+
+  const [inSuspense, outsideSuspense] = await Promise.all([
+    renderToStreamString(
+      <Suspense fallback={<span>loading</span>}>
+        <Editor reason="The editor requires browser APIs." />
+      </Suspense>
+    ),
+    renderToStreamString(<Editor reason="The editor requires browser APIs." />)
+  ]);
+
+  return {
+    typeofWindow: typeof window,
+    status: usable.status,
+    error: serializeError((usable as { reason?: unknown }).reason),
+    withoutReason: serializeError((browser() as { reason?: unknown }).reason),
+    lazyReason: { ...serializeError((lazy as { reason?: unknown }).reason), initializerCalls },
+    throwingReason: serializeError((throwing as { reason?: unknown }).reason),
+    inSuspense,
+    outsideSuspense
+  };
+}

--- a/packages/foxact/src/browser/index.test.tsx
+++ b/packages/foxact/src/browser/index.test.tsx
@@ -1,0 +1,230 @@
+import { describe, it, before } from 'mocha';
+import { expect } from 'earl';
+
+import path from 'node:path';
+import { Suspense, use } from 'react';
+import * as reactDomExports from 'react-dom';
+import { hydrateRoot } from 'react-dom/client';
+import { act, render, screen } from '@testing-library/react';
+import { runOnServer } from '../../test/server-realm';
+import { trapConsoleError } from '../../test/trap-console-error';
+import { browser, browserBailoutError } from '.';
+import type { BrowserReason } from '.';
+import type { ServerRealmFixtureResult } from './__fixtures__/server-realm';
+
+const nativeBrowser = (reactDomExports as { browser?: unknown }).browser;
+const isNativeBrowser = typeof nativeBrowser === 'function';
+
+function Editor({ reason }: { reason?: BrowserReason }) {
+  use(browser(reason));
+  return <span>editor</span>;
+}
+
+function App({ reason }: { reason?: BrowserReason }) {
+  return (
+    <Suspense fallback={<span>loading</span>}>
+      <Editor reason={reason} />
+    </Suspense>
+  );
+}
+
+function TypeofEditor() {
+  const value = use(browser('The editor requires browser APIs.'));
+  return <span>editor:{typeof value}</span>;
+}
+
+describe('browserBailoutError', () => {
+  it('creates the error React reports for a browser-only render, marked like noSSRError', () => {
+    const error = browserBailoutError('The editor requires browser APIs.') as Error & { digest: string, recoverableError: string };
+
+    expect(error.message).toEqual('Browser-only rendering was requested by `browser()`.');
+    expect(error.cause).toEqual('The editor requires browser APIs.');
+    // the same markers as noSSR(), so Next.js and the existing filtering recipes apply
+    expect(error.digest).toEqual('BAILOUT_TO_CLIENT_SIDE_RENDERING');
+    expect(error.recoverableError).toEqual('NO_SSR');
+  });
+
+  it('omits the cause when no reason is given', () => {
+    expect('cause' in browserBailoutError()).toEqual(false);
+  });
+
+  it('initializes a reason function and uses its result as the cause', () => {
+    let initializerCalls = 0;
+    const cause = new Error('lazy reason');
+
+    const error = browserBailoutError(() => {
+      initializerCalls++;
+      return cause;
+    });
+
+    expect(initializerCalls).toEqual(1);
+    expect(error.cause as Error).toExactlyEqual(cause);
+  });
+
+  it('reports a throwing reason initializer instead of failing', () => {
+    const error = browserBailoutError(() => {
+      throw new Error('initializer exploded');
+    });
+
+    expect(error.cause).toEqual('The reason for browser-only rendering could not be determined because its initializer threw.');
+  });
+
+  it('is stackless', () => {
+    expect(browserBailoutError('stackless').stack ?? '').not.toInclude('\n    at ');
+  });
+});
+
+describe('browser', () => {
+  it('is ReactDOM.browser itself when available (React DOM 19.3+)', function () {
+    if (!isNativeBrowser) this.skip();
+
+    expect(browser).toExactlyEqual(nativeBrowser);
+  });
+
+  it('renders the browser-only content synchronously in the browser, use() returns undefined', () => {
+    render(
+      <Suspense fallback={<span>loading</span>}>
+        <TypeofEditor />
+      </Suspense>
+    );
+
+    expect(screen.getByText('editor:undefined')).not.toBeNullish();
+    expect(screen.queryByText('loading')).toBeNullish();
+  });
+
+  it('works without a reason', () => {
+    render(<App />);
+
+    expect(screen.getByText('editor')).not.toBeNullish();
+  });
+
+  it('never invokes a reason initializer in the browser', () => {
+    let initializerCalls = 0;
+
+    render(
+      <App
+        reason={() => {
+          initializerCalls++;
+          return new Error('expensive to create');
+        }}
+      />
+    );
+
+    expect(screen.getByText('editor')).not.toBeNullish();
+    expect(initializerCalls).toEqual(0);
+  });
+
+  it('survives re-renders with a different reason', () => {
+    const { rerender } = render(<App reason="first" />);
+    rerender(<App reason="second" />);
+
+    expect(screen.getByText('editor')).not.toBeNullish();
+  });
+
+  describe('polyfill (React DOM without browser())', () => {
+    before(function () {
+      if (isNativeBrowser) this.skip();
+    });
+
+    it('hands out one shared, already fulfilled usable in the browser', () => {
+      const usable = browser('The editor requires browser APIs.');
+
+      expect(usable.status).toEqual('fulfilled');
+      expect((usable as { value?: unknown }).value).toEqual(undefined);
+      // the same object every time, so React never tracks a fresh thenable per render
+      expect(browser()).toExactlyEqual(usable);
+    });
+
+    it('honors the thenable contract', async () => {
+      expect(await browser()).toEqual(undefined);
+    });
+
+    describe('during server rendering (worker thread)', () => {
+      let result: ServerRealmFixtureResult;
+
+      // Runs in a TRUE server realm (worker thread) where `typeof window` is
+      // natively 'undefined'
+      before(async function () {
+        this.timeout(10000); // worker spawn + swc compilation
+
+        result = await runOnServer<ServerRealmFixtureResult>(path.join(__dirname, '__fixtures__/server-realm.tsx'));
+
+        expect(result.typeofWindow).toEqual('undefined');
+      });
+
+      it('hands out an already rejected usable carrying the bailout error', () => {
+        expect(result.status).toEqual('rejected');
+        expect(result.error.message).toEqual('Browser-only rendering was requested by `browser()`.');
+        expect(result.error.cause).toEqual('The editor requires browser APIs.');
+        // the same markers as noSSR(), so Next.js and the existing filtering recipes apply
+        expect(result.error.digest).toEqual('BAILOUT_TO_CLIENT_SIDE_RENDERING');
+        expect(result.error.recoverableError).toEqual('NO_SSR');
+        expect(result.error.stackless).toEqual(true);
+      });
+
+      it('omits the cause when no reason is given', () => {
+        expect(result.withoutReason.hasCause).toEqual(false);
+        expect(result.withoutReason.message).toEqual('Browser-only rendering was requested by `browser()`.');
+      });
+
+      it('initializes a reason function on the server, and uses its result as the cause', () => {
+        expect(result.lazyReason.initializerCalls).toEqual(1);
+        expect(result.lazyReason.cause).toEqual('lazy reason');
+      });
+
+      it('reports a throwing reason initializer instead of failing', () => {
+        expect(result.throwingReason.cause).toEqual('The reason for browser-only rendering could not be determined because its initializer threw.');
+      });
+
+      it('makes stream SSR render the closest Suspense fallback and report the bailout to onError', () => {
+        expect(result.inSuspense.shellError).toBeNullish();
+        expect(result.inSuspense.html).toInclude('loading');
+        expect(result.inSuspense.html).not.toInclude('editor');
+
+        expect(result.inSuspense.errors.length).toEqual(1);
+        expect(result.inSuspense.errors[0].message).toEqual('Browser-only rendering was requested by `browser()`.');
+        expect(result.inSuspense.errors[0].recoverableError).toEqual('NO_SSR');
+      });
+
+      it('fails the server render when used outside of a Suspense boundary', () => {
+        expect(result.outsideSuspense.shellError).not.toBeNullish();
+        expect(result.outsideSuspense.html).toEqual('');
+      });
+
+      it('hydrates the server HTML into the browser-only content, surfacing a filterable recoverable error', () => {
+        const container = document.createElement('div');
+        document.body.appendChild(container);
+        container.innerHTML = result.inSuspense.html;
+
+        expect(container.textContent).toEqual('loading');
+
+        const recoverableErrors: unknown[] = [];
+        const trap = trapConsoleError();
+
+        let root: ReturnType<typeof hydrateRoot>;
+        try {
+          act(() => {
+            root = hydrateRoot(container, <App reason="The editor requires browser APIs." />, {
+              onRecoverableError(error) {
+                recoverableErrors.push(error);
+              }
+            });
+          });
+        } finally {
+          trap.restore();
+        }
+
+        expect(container.textContent).toEqual('editor');
+        expect(trap.calls).toEqual([]);
+
+        // React DOM < 19.3 reports the client-rendered boundary through onRecoverableError,
+        // carrying the digest the server's onError forwarded: that's what to filter on
+        expect(recoverableErrors.length).toEqual(1);
+        expect((recoverableErrors[0] as { digest?: string }).digest).toEqual('BAILOUT_TO_CLIENT_SIDE_RENDERING');
+
+        act(() => root.unmount());
+        container.remove();
+      });
+    });
+  });
+});

--- a/packages/foxact/src/browser/index.test.tsx
+++ b/packages/foxact/src/browser/index.test.tsx
@@ -12,7 +12,7 @@ import { browser, browserBailoutError } from '.';
 import type { BrowserReason } from '.';
 import type { ServerRealmFixtureResult } from './__fixtures__/server-realm';
 
-const nativeBrowser = (reactDomExports as { browser?: unknown }).browser;
+const nativeBrowser = 'browser' in reactDomExports ? reactDomExports.browser : undefined;
 const isNativeBrowser = typeof nativeBrowser === 'function';
 
 function Editor({ reason }: { reason?: BrowserReason }) {

--- a/packages/foxact/src/browser/index.ts
+++ b/packages/foxact/src/browser/index.ts
@@ -1,6 +1,7 @@
 import * as reactDomExports from 'react-dom';
 
 import { noSSRError } from '../no-ssr';
+import type { FulfilledReactPromise, RejectedReactPromise } from '../use';
 
 /**
  * Explains why the content has to render in the browser. It becomes the `cause`
@@ -10,21 +11,11 @@ import { noSSRError } from '../no-ssr';
  */
 export type BrowserReason = string | (() => unknown);
 
-interface FulfilledBrowserUsable extends PromiseLike<undefined> {
-  status: 'fulfilled',
-  value: undefined
-}
-
-interface RejectedBrowserUsable extends PromiseLike<undefined> {
-  status: 'rejected',
-  reason: unknown
-}
-
 /**
  * The opaque value returned by `browser()`. Pass it to `use()`, do not read
  * it, await it, or throw it yourself.
  */
-export type BrowserUsable = FulfilledBrowserUsable | RejectedBrowserUsable;
+export type BrowserUsable = FulfilledReactPromise<undefined> | RejectedReactPromise<undefined>;
 
 // Same messages as React's own `browser()` implementation
 const BROWSER_BAILOUT_MESSAGE = 'Browser-only rendering was requested by `browser()`.';
@@ -53,7 +44,7 @@ export function browserBailoutError(reason?: BrowserReason) {
 // In the browser every `browser()` call hands out the same, already fulfilled
 // usable: `use()` reads the status synchronously and returns `undefined` without
 // suspending, and React never has to track a fresh thenable on re-render.
-const fulfilledBrowserUsable: FulfilledBrowserUsable = {
+const fulfilledBrowserUsable: FulfilledReactPromise<undefined> = {
   status: 'fulfilled',
   value: undefined,
   // eslint-disable-next-line sukka/unicorn/no-thenable -- a thenable is the contract React's use() consumes
@@ -88,9 +79,6 @@ function browserPolyfill(reason?: BrowserReason): BrowserUsable {
 }
 
 /** @see https://foxact.skk.moe/browser */
-export const browser: (reason?: BrowserReason) => BrowserUsable = typeof (reactDomExports as { browser?: unknown }).browser === 'function'
-  // React DOM 19.3+ ships `browser()` natively, with proper `onBrowserBailout`
-  // support in the server renderer. The arm is unreachable when testing against
-  // React 19.2 (the capability is sniffed once at module load), hence the ignore
-  ? /* istanbul ignore next */ (reactDomExports as unknown as { browser: (reason?: BrowserReason) => BrowserUsable }).browser
+export const browser: (reason?: BrowserReason) => BrowserUsable = 'browser' in reactDomExports && /* istanbul ignore next */ typeof reactDomExports.browser === 'function'
+  ? /* istanbul ignore next */ reactDomExports.browser as (reason?: BrowserReason) => BrowserUsable
   : browserPolyfill;

--- a/packages/foxact/src/browser/index.ts
+++ b/packages/foxact/src/browser/index.ts
@@ -1,0 +1,96 @@
+import * as reactDomExports from 'react-dom';
+
+import { noSSRError } from '../no-ssr';
+
+/**
+ * Explains why the content has to render in the browser. It becomes the `cause`
+ * of the error reported by the server renderer. A function is only invoked by
+ * the server renderer and never in the browser, so pass one (e.g. `() => new
+ * Error('...')`) when creating the reason is expensive.
+ */
+export type BrowserReason = string | (() => unknown);
+
+interface FulfilledBrowserUsable extends PromiseLike<undefined> {
+  status: 'fulfilled',
+  value: undefined
+}
+
+interface RejectedBrowserUsable extends PromiseLike<undefined> {
+  status: 'rejected',
+  reason: unknown
+}
+
+/**
+ * The opaque value returned by `browser()`. Pass it to `use()`, do not read
+ * it, await it, or throw it yourself.
+ */
+export type BrowserUsable = FulfilledBrowserUsable | RejectedBrowserUsable;
+
+// Same messages as React's own `browser()` implementation
+const BROWSER_BAILOUT_MESSAGE = 'Browser-only rendering was requested by `browser()`.';
+const REASON_INITIALIZER_THREW_MESSAGE = 'The reason for browser-only rendering could not be determined because its initializer threw.';
+
+/** @private */
+export function browserBailoutError(reason?: BrowserReason) {
+  if (reason === undefined) {
+    return noSSRError(BROWSER_BAILOUT_MESSAGE);
+  }
+
+  let cause: unknown;
+  if (typeof reason === 'function') {
+    try {
+      cause = reason();
+    } catch {
+      cause = REASON_INITIALIZER_THREW_MESSAGE;
+    }
+  } else {
+    cause = reason;
+  }
+
+  return noSSRError(BROWSER_BAILOUT_MESSAGE, undefined, { cause });
+}
+
+// In the browser every `browser()` call hands out the same, already fulfilled
+// usable: `use()` reads the status synchronously and returns `undefined` without
+// suspending, and React never has to track a fresh thenable on re-render.
+const fulfilledBrowserUsable: FulfilledBrowserUsable = {
+  status: 'fulfilled',
+  value: undefined,
+  // eslint-disable-next-line sukka/unicorn/no-thenable -- a thenable is the contract React's use() consumes
+  then(onfulfilled, onrejected) {
+    // eslint-disable-next-line promise/prefer-catch -- delegates PromiseLike#then(onfulfilled, onrejected) as is
+    return Promise.resolve(undefined).then(onfulfilled, onrejected);
+  }
+};
+
+function browserPolyfill(reason?: BrowserReason): BrowserUsable {
+  /* istanbul ignore if -- unreachable when Happy DOM registers window globally; covered
+     for real by the server-realm worker test (nyc cannot see into worker threads) */
+  if (typeof window === 'undefined') {
+    const error = browserBailoutError(reason);
+
+    // `use()` throws the reason of an already rejected usable synchronously. The
+    // server renderer then treats it like any other error thrown inside a
+    // <Suspense> boundary: the fallback is sent as HTML and the boundary is
+    // marked for client rendering, which is exactly what `noSSR()` relies on.
+    return {
+      status: 'rejected',
+      reason: error,
+      // eslint-disable-next-line sukka/unicorn/no-thenable -- a thenable is the contract React's use() consumes
+      then(onfulfilled, onrejected) {
+        // eslint-disable-next-line promise/prefer-catch -- delegates PromiseLike#then(onfulfilled, onrejected) as is
+        return Promise.reject(error).then(onfulfilled, onrejected);
+      }
+    };
+  }
+
+  return fulfilledBrowserUsable;
+}
+
+/** @see https://foxact.skk.moe/browser */
+export const browser: (reason?: BrowserReason) => BrowserUsable = typeof (reactDomExports as { browser?: unknown }).browser === 'function'
+  // React DOM 19.3+ ships `browser()` natively, with proper `onBrowserBailout`
+  // support in the server renderer. The arm is unreachable when testing against
+  // React 19.2 (the capability is sniffed once at module load), hence the ignore
+  ? /* istanbul ignore next */ (reactDomExports as unknown as { browser: (reason?: BrowserReason) => BrowserUsable }).browser
+  : browserPolyfill;

--- a/packages/foxact/src/no-ssr/index.ts
+++ b/packages/foxact/src/no-ssr/index.ts
@@ -1,8 +1,12 @@
 import { createStacklessError } from '../create-stackless-error';
 
 /** @private */
-export function noSSRError(errorMessage?: string, nextjsDigest = 'BAILOUT_TO_CLIENT_SIDE_RENDERING') {
-  const error = createStacklessError(() => new Error(errorMessage));
+export function noSSRError(
+  errorMessage?: string,
+  nextjsDigest = 'BAILOUT_TO_CLIENT_SIDE_RENDERING',
+  errorOptions?: { cause?: unknown }
+) {
+  const error = createStacklessError(() => new Error(errorMessage, errorOptions));
 
   // Next.js marks errors with `NEXT_DYNAMIC_NO_SSR_CODE` digest as recoverable:
   // https://github.com/vercel/next.js/blob/bef716ad031591bdf94058aaf4b8d842e75900b5/packages/next/src/shared/lib/lazy-dynamic/bailout-to-csr.ts#L2

--- a/packages/foxact/src/use/index.ts
+++ b/packages/foxact/src/use/index.ts
@@ -3,18 +3,53 @@
 // eslint-disable-next-line no-restricted-imports -- the compatibility implementation must detect whether React.use exists
 import * as reactExports from 'react';
 
+// These mirror the `ReactPromise` family `@types/react` only ships with the React
+// 19 typings, so that anything handing a pre-tracked thenable to `use()` (e.g.
+// `foxact/browser`) can be typed the same way on React 18.
+export interface UntrackedReactPromise<T> extends PromiseLike<T> {
+  status?: undefined
+}
+
+export interface PendingReactPromise<T> extends PromiseLike<T> {
+  status: 'pending'
+}
+
+export interface FulfilledReactPromise<T> extends PromiseLike<T> {
+  status: 'fulfilled',
+  value: T
+}
+
+export interface RejectedReactPromise<T> extends PromiseLike<T> {
+  status: 'rejected',
+  reason: unknown
+}
+
+/**
+ * A thenable whose settled state React's `use()` reads synchronously, off the
+ * `status` / `value` / `reason` properties React attaches while tracking it.
+ */
+export type ReactPromise<T> =
+  | UntrackedReactPromise<T>
+  | PendingReactPromise<T>
+  | FulfilledReactPromise<T>
+  | RejectedReactPromise<T>;
+
+// The tracking the polyfill performs itself: React mutates the very same
+// properties in place, so the polyfill needs them writable.
+interface TrackedReactPromise<T> extends PromiseLike<T> {
+  status?: 'pending' | 'fulfilled' | 'rejected',
+  value?: T,
+  reason?: unknown
+}
+
 // eslint-disable-next-line @eslint-react/no-unnecessary-use-prefix -- React.use polyfill
 export const use = typeof reactExports.use === 'function'
   ? reactExports.use
   // the polyfill arm is unreachable when testing against React 19+ (the capability
   // is sniffed once at module load), hence the istanbul ignore
-  : /* istanbul ignore next */ (<T>(
-    promise: Promise<T> & {
-      status?: 'pending' | 'fulfilled' | 'rejected',
-      value?: T,
-      reason?: unknown
-    }
-  ): T => {
+  : /* istanbul ignore next */ (<T>(usable: ReactPromise<T>): T => {
+    const promise = usable as TrackedReactPromise<T>;
+
     switch (promise.status) {
       case 'pending': {
         // eslint-disable-next-line @typescript-eslint/only-throw-error -- React.use


### PR DESCRIPTION
## Summary

Adds `foxact/browser`: [React DOM's `browser()` API](https://react.dev/reference/react-dom/browser) with a compatibility implementation for React DOM releases that don't ship it yet.

`browser()` landed in React DOM on 2026-07-30 (facebook/react#37143, with `onBrowserBailout` in #37193 and lazy reasons in #37241). It is `enableBrowserAPI = true` on `main` and exported from the stable `react-dom` entry, so it will be in the next stable, but today it is Canary only (`19.3.0-canary-*`), and stable `react-dom@19.2.8` throws `An unsupported type was passed to use()` for the value it returns.

### How it works

The native `browser()` just returns `{ $$typeof: Symbol.for('react.recoverable'), _reason }`; all the behavior lives in React's `use()` dispatchers (Fiber returns `undefined`, Fizz throws a recoverable error and reports it to `onBrowserBailout` with an empty digest, which the Canary client then skips in `onRecoverableError`). Userland can't hook into that, so this follows the same pattern as `foxact/use` and `useIsomorphicLayoutEffect`:

- When `react-dom` exports `browser`, it is handed out as is.
- Otherwise a polyfill returns a value `use()` already understands:
  - in the browser, one shared already-fulfilled thenable, so `use(browser())` returns `undefined` synchronously without suspending (identical to native);
  - during server rendering, an already-rejected thenable whose reason is the same recoverable error `noSSR()` throws. Stream SSR then leaves the closest `<Suspense>` fallback in the HTML and marks the boundary for client rendering, exactly like native.
- The error mirrors React's: same message, the `reason` string / lazily-initialized function result as `cause`, same fallback message when the initializer throws. It carries the Next.js `BAILOUT_TO_CLIENT_SIDE_RENDERING` digest and the `recoverableError: 'NO_SSR'` marker, so Next.js and the existing `noSSR` filtering recipes keep working.
- `noSSRError` gains an optional `cause` so both share one error factory; `browserBailoutError` is exported as `@private` like `noSSRError`.
- Works with `foxact/use` on React 18 too.

### What the polyfill can't replicate on React DOM < 19.3 (documented)

- The bailout is reported to `onError` instead of `onBrowserBailout`.
- `hydrateRoot`'s `onRecoverableError` still fires (the 19.2 client has no empty-digest special case); the docs show how to filter by the digest forwarded from `onError`.
- `abort(browser())` is native-only.

All of these go away automatically once the user upgrades to a React DOM that ships `browser()`.

### Docs

New `/browser` page (usage, RSC, conditional bailout, reasons, differences from native + `onError` / `onRecoverableError` recipes), registered in `_meta.ts`; `/no-ssr` gets a pointer to it.

## Test plan

- [x] In-process: `use(browser())` renders synchronously and returns `undefined`, reason initializer never runs in the browser, re-renders, thenable contract, every branch of `browserBailoutError`
- [x] Server-realm worker (`typeof window === 'undefined'`): rejected usable with the expected error, stream SSR renders the Suspense fallback and reports to `onError`, render fails outside `<Suspense>`, then the produced HTML is hydrated on the main thread into the browser-only content with a filterable recoverable error
- [x] `pnpm test`: 317 passing, 1 pending (the "is `ReactDOM.browser` itself" assertion, skipped until devDeps ship `browser`); `browser` and `no-ssr` at 100% coverage
- [x] `tsc --noEmit`, `eslint`, `pnpm build` (docs site builds with the new page; `foxact/browser` is 637 B raw / 301 B brotli)

CHANGELOG is left for the release commit, per the repo's convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
